### PR TITLE
meson: Move library to its own file in src/

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,4 +9,6 @@ libobsfrontend = cc.find_library('obs-frontend-api')
 # Include paths
 inc = include_directories(['/usr/include/obs'])
 
-library('obs-controller', ['src/main.cpp', 'src/api.cpp'], dependencies: [libobs, libobsfrontend], include_directories: inc)
+# Subdirectories
+subdir('src')
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,16 @@
+obs_controller_src = [
+  'main.cpp',
+  'api.cpp'
+]
+
+obs_controller_deps = [
+  libobs,
+  libobsfrontend
+]
+
+
+libobscontroller = library('obs-controller', obs_controller_src, dependencies: obs_controller_deps, include_directories: inc)
+libobscontroller_dep = declare_dependency(dependencies:        obs_controller_deps,
+                                          include_directories: [include_directories('.')],
+                                          link_with:           libobscontroller)
+


### PR DESCRIPTION
I don't have write access to the repository, so I'll just open a PR :smiley:

∘ Moved library() to a separate meson file in src/
∘ Added a libobscontroller_dep dependency object for use in
  subprojects. This is probably never going to be used.
  Moreover, we don't install the library (yet), so this might be
  rather useless.